### PR TITLE
Serial number lookup

### DIFF
--- a/DeploymentScripts/Mac/JAMF_silentinstall.sh
+++ b/DeploymentScripts/Mac/JAMF_silentinstall.sh
@@ -10,7 +10,7 @@ password="$7"
 JAMF_domain="$8"
 
 # The script needs access to the JAMF Pro API to gather related the related email for a given user
-# Account just needs to have Users - Read permissions
+# Account just needs to have Users - Read permissions OR Computers - Read permissions if using the alternative serial number method
 # You can configure a temp account for this in the "Jamf Pro User Accounts & Groups" section of your console
 JAMF_username="$9"
 JAMF_password="${10}"
@@ -46,6 +46,8 @@ function jamfAPI {
 	echo "Making GET request to Classic JAMF API"
 	response=$(curl -s "https://$JAMF_domain.jamfcloud.com/JSSResource/users/name/$username" -u "$JAMF_username:$JAMF_password")
 	# Here is an alternative method of looking up email addresses if your LDAP users don't match your local user accounts.
+	# If using this alternative method, ensure your JAMF user account has Computers - Read access
+	#
 	# serial=$(ioreg -l |awk '/IOPlatformSerialNumber/ { print $4; }'|sed s/\"//g)
 	# response=$(curl "https://$JAMF_fqdn/JSSResource/computers/serialnumber/$serial" --user "$JAMF_username":"$JAMF_password" -H "Accept: application/xml")
 	email=$(echo $response | /usr/bin/awk -F'<email_address>|</email_address>' '{print $2}')

--- a/DeploymentScripts/Mac/JAMF_silentinstall.sh
+++ b/DeploymentScripts/Mac/JAMF_silentinstall.sh
@@ -9,7 +9,7 @@ email="$6" #If email is entered in parameters, script will skip over using JAMF 
 password="$7"
 JAMF_domain="$8"
 
-# The script needs access to the JAMF Pro API to gather related the related email for a given user 
+# The script needs access to the JAMF Pro API to gather related the related email for a given user
 # Account just needs to have Users - Read permissions
 # You can configure a temp account for this in the "Jamf Pro User Accounts & Groups" section of your console
 JAMF_username="$9"
@@ -45,7 +45,9 @@ function emailValidation {
 function jamfAPI {
 	echo "Making GET request to Classic JAMF API"
 	response=$(curl -s "https://$JAMF_domain.jamfcloud.com/JSSResource/users/name/$username" -u "$JAMF_username:$JAMF_password")
-
+	# Here is an alternative method of looking up email addresses if your LDAP users don't match your local user accounts.
+	# serial=$(ioreg -l |awk '/IOPlatformSerialNumber/ { print $4; }'|sed s/\"//g)
+	# response=$(curl "https://$JAMF_fqdn/JSSResource/computers/serialnumber/$serial" --user "$JAMF_username":"$JAMF_password" -H "Accept: application/xml")
 	email=$(echo $response | /usr/bin/awk -F'<email_address>|</email_address>' '{print $2}')
 	emailValidation
 }
@@ -71,8 +73,8 @@ function killSyspref {
 }
 
 function setDirectory {
-	if [ -n "$3" ] 
-	then 
+	if [ -n "$3" ]
+	then
 		cd /Users/"$3" || { echo "Failed to cd to user directory"; exit 1; }
 	fi
 }
@@ -84,7 +86,7 @@ function downloadBackblaze {
 
 function mountBackblaze {
 	echo "Mounting Installer..."
-	hdiutil attach -quiet -nobrowse install_backblaze.dmg 
+	hdiutil attach -quiet -nobrowse install_backblaze.dmg
 }
 ###################################################
 
@@ -95,8 +97,8 @@ mountBackblaze
 #Kill System Preferences process to prevent related BZERROR
 killSyspref
 
-#Check to see if Backblaze is installed already, if so update it. Else continue as planned. 
-if open -Ra "Backblaze" ; 
+#Check to see if Backblaze is installed already, if so update it. Else continue as planned.
+if open -Ra "Backblaze" ;
 	then
   		echo "Backblaze already installed, attempting to update"
 		updateBackblaze


### PR DESCRIPTION
Some of my users had their machines before we had JAMF or even LDAP running. Their local users don't match their LDAP user accounts and so the email address lookups fail. Added an alternative lookup method using the machine's serial number instead of the local user name.